### PR TITLE
rtrim added to page_id aka $doc->title on line 70

### DIFF
--- a/app/controllers/DocController.php
+++ b/app/controllers/DocController.php
@@ -67,11 +67,11 @@ class DocController extends BaseController{
 			//Set data array
 			$data = array(
 				'doc'			=> $doc,
-				'page_id'		=> strtolower(str_replace(' ','-', $doc->title)),
+				'page_id'		=> strtolower(rtrim(str_replace(' ','-', $doc->title)),"-"),
 				'page_title'	=> $doc->title,
 				'showAnnotationThanks' => $showAnnotationThanks
 			);				
-			
+		
 			//Render view and return
 			return View::make('doc.reader.index', $data);
 						


### PR DESCRIPTION
This change fixes issue 449 by removing the trailing dash found in document titles.
