### PR TITLE
Read optional smtp port config in mail.php

### DIFF
--- a/app/config/mail.php
+++ b/app/config/mail.php
@@ -8,7 +8,8 @@
 			'host'=> 'smtp.mailgun.org',
 			'from' => array('address' => null, 'name' => null),
 			'username' => null,
-			'password' => null
+			'password' => null,
+			'port' => 587
 		);
 	}
 
@@ -53,7 +54,7 @@ return array(
 	|
 	*/
 
-	'port' => 587,
+	'port' => $smtp_config['port'],
 
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
Just adding an optional smtp_config port variable to setup SMTPs with a different port.

See: #498 