### PR TITLE
Fix broken js to display errors in login popup

### DIFF
--- a/public/js/doc.js
+++ b/public/js/doc.js
@@ -27,8 +27,8 @@ $(document).ready(function () {
           var error_html = $('<ul></ul>');
 
           /*jslint unparam: true*/
-          $(response.errors).each(function (i, key) {
-            error_html.append('<li>' + response.errors[key][0] + '</li>');
+          angular.forEach(response.errors, function (value, key) {
+            error_html.append('<li>' + value + '</li>');
           });
           /*jslint unparam: false*/
 


### PR DESCRIPTION
This code gets an undefined value when accessing the response.errors key value.

This is now fixed by using the value param passed to the anonymous function. Also I decided to use the angular.forEach native method to reduce dependencies with jQuery.

See #500 