### PR TITLE
fix that link to blank page on creating document without filling title. issue...

### DIFF
--- a/app/controllers/DashboardController.php
+++ b/app/controllers/DashboardController.php
@@ -230,7 +230,6 @@ class DashboardController extends BaseController{
 			$rules = array('title' => 'required');
 			$validation = Validator::make($doc_details, $rules);
 			if($validation->fails()){
-				die($validation);
 				return Redirect::to('dashboard/docs')->withInput()->withErrors($validation);
 			}
 	


### PR DESCRIPTION
... #530
Now it will return an error message "The title field is required."