### PR TITLE
ignore creds file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor/
 
 # Configuration
 app/config/local
+app/config/creds.php
 .env.*.php
 .env.php
 !.env.example.php


### PR DESCRIPTION
The actual config file should be ignored so that people don't accidentally commit it. 