### PR TITLE
Load the inserted comment, not children on postIndex

### DIFF
--- a/app/controllers/CommentApiController.php
+++ b/app/controllers/CommentApiController.php
@@ -59,7 +59,7 @@ class CommentApiController extends ApiController
 
         Event::fire(MadisonEvent::DOC_COMMENTED, $newComment);
 
-        $return = Comment::loadComments($newComment->doc_id, $newComment->id, $newComment->user_id);
+        $return = Comment::loadComment($newComment->doc_id, $newComment->id, $newComment->user_id);
 
         return Response::json($return);
     }


### PR DESCRIPTION
This is probably a typo. Right now, inserting a new top-level comment will fail, because an empty array is return, instead of an array with the new comment.