### PR TITLE
Make title also required when updating

### DIFF
--- a/app/controllers/DocumentApiController.php
+++ b/app/controllers/DocumentApiController.php
@@ -83,6 +83,12 @@ class DocumentApiController extends ApiController
 
     public function postTitle($id)
     {
+        $rules = array('title' => 'required');
+        $validation = Validator::make(Input::only('title'), $rules);
+        if ($validation->fails()) {
+            return Response::json($this->growlMessage('A valid title is required, changes are not saved', 'error'));
+        }
+        
         $doc = Doc::find($id);
         $doc->title = Input::get('title');
         $doc->save();


### PR DESCRIPTION
A title is required when creating a document, but once it's being edited, the requirement is gone.

Perhaps it should include a stricter check (minimum of 6 chars or something?) and/or a timed delay when updating the title? Now it updates on every keystroke, perhaps on blur would be better?