### PR TITLE
Use json growl error instead of return back

### DIFF
--- a/app/controllers/DocumentApiController.php
+++ b/app/controllers/DocumentApiController.php
@@ -55,7 +55,7 @@ class DocumentApiController extends ApiController
         $rules = array('title' => 'required');
         $validation = Validator::make($doc_details, $rules);
         if ($validation->fails()) {
-            return Redirect::to('dashboard/docs')->withInput()->withErrors($validation);
+            return Response::json($this->growlMessage('A valid title is required, changes are not saved', 'error'));
         }
 
         try {

--- a/app/controllers/DocumentApiController.php
+++ b/app/controllers/DocumentApiController.php
@@ -55,7 +55,7 @@ class DocumentApiController extends ApiController
         $rules = array('title' => 'required');
         $validation = Validator::make($doc_details, $rules);
         if ($validation->fails()) {
-            return Response::json($this->growlMessage('A valid title is required, changes are not saved', 'error'));
+            return Response::json($this->growlMessage('A valid title is required.', 'error'));
         }
 
         try {


### PR DESCRIPTION
This is only called with the API right? So no point in returning a redirect.