### PR TITLE
Remove conflicting mixins

### DIFF
--- a/public/sass/modules/_header.scss
+++ b/public/sass/modules/_header.scss
@@ -39,10 +39,6 @@ header {
 }
 
 .navbar-nav {
-    @extend .navbar-collapse;
-    @extend .collapse;
-    @extend .navbar-right;
-
     li {
         a {
             text-transform: uppercase;


### PR DESCRIPTION
These mixins aren't needed, because the styling is already added to the parent item. This fixes problems with the dropdown (#541).

*(I needed to run `grunt` twice for some reason, before the effect was visible)*