### PR TITLE
Fix annotations persisting across documents for #654

### DIFF
--- a/public/js/services/annotationService.js
+++ b/public/js/services/annotationService.js
@@ -9,6 +9,13 @@ angular.module('madisonApp.services')
     this.annotator = null;
     this.count = 0;
 
+    this.resetAnnotationService = function () {
+      this.annotations = [];
+      this.annotationGroups = {};
+      this.annotator = null;
+      this.count = 0;
+    };
+
     this.setAnnotations = function (annotations) {
       var parentElements = 'h1,h2,h3,h4,h5,h6,li,p';
 
@@ -66,7 +73,7 @@ angular.module('madisonApp.services')
       }
 
       //Reset our annotation store
-      this.annotations = [];
+      this.resetAnnotationService();
     };
 
     this.createAnnotator = function (element, doc) {


### PR DESCRIPTION
@krues8dr @sethetter This fixes #654 .  Need to make sure to click through a bunch before merging.  I think it was as simple as clearing the `annotationGroups` along with the `annotations` when destroying annotator between `$state` changes.