### PR TITLE
Provide more helpful messages if an existing email is used for sign up

### DIFF
--- a/app/Http/Requests/Request.php
+++ b/app/Http/Requests/Request.php
@@ -3,8 +3,27 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\JsonResponse;
 
 abstract class Request extends FormRequest
 {
-    //
+    /**
+     * Get the proper failed validation response for the request.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function response(array $errors)
+    {
+        if ($this->ajax() || $this->wantsJson()) {
+            // format the error messages so the client will display them
+            // automatically, like the growlMessage method on the controller
+            // class does (whose functionality should probably be broken out
+            // into a injectable service class that we could use here instead)
+            return new JsonResponse(['messages' => array_map(function ($msg) {
+                return ['text' => $msg, 'severity' => 'error'];
+            }, array_flatten($errors))], 422);
+        }
+
+        return parent::response($errors);
+    }
 }

--- a/app/Http/Requests/SignupRequest.php
+++ b/app/Http/Requests/SignupRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Http\Requests\Request;
+
+class SignupRequest extends Request
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        // anyone can sign up
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'email'    => 'required|email',
+            'password' => 'required',
+            'fname'    => 'required',
+            'lname'    => 'required',
+        ];
+    }
+
+    /**
+     * Get the attribute names for use in error messages.
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        return [
+            'fname' => 'first name',
+            'lname' => 'last name',
+        ];
+    }
+}


### PR DESCRIPTION
Specifically:
- If a user tries to sign up with an existing email address and they
  aren't confirmed, automatically re-send their confirmation.
- If a user tries to sign up with an existing email address and they are
  confirmed, provide a link to the "forgot password" link.

Fixes #907 

@krues8dr and @sethetter