### PR TITLE
Bring the EditorConfig settings in line with PSR2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,8 @@ indent_size = 2
 trim_trailing_whitespace = true
 
 [*.php]
-indent_style=space
-indent_size=2
+indent_style = space
+indent_size = 4
 
 [*.{js,json}]
 indent_style = space


### PR DESCRIPTION
Our contributing guidelines say to follow both the EditorConfig settings
and PSR2, but they are in conflict with respect to the number of spaces
to use for indentation.