### PR TITLE
Mark any existing replies to notes as notes

### DIFF
--- a/server/database/migrations/2016_07_25_203547_mark_note_replies_as_notes.php
+++ b/server/database/migrations/2016_07_25_203547_mark_note_replies_as_notes.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use App\Models\Annotation;
+
+class MarkNoteRepliesAsNotes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $annotations = DB::table('annotations')->whereNotNull('data')->get();
+        foreach ($annotations as $annotation) {
+            $data = json_decode($annotation->data, true);
+
+            if (empty($data['old_permalink_type']) || $data['old_permalink_type'] !== 'annsubcomment') {
+                continue;
+            }
+
+            DB
+                ::table('annotations')
+                ->where('id', $annotation->id)
+                ->update([
+                    'annotation_subtype' => Annotation::SUBTYPE_NOTE,
+                ])
+                ;
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $annotations = DB::table('annotations')->whereNotNull('data')->get();
+        foreach ($annotations as $annotation) {
+            $data = json_decode($annotation->data, true);
+
+            if (empty($data['old_permalink_type']) || $data['old_permalink_type'] !== 'annsubcomment') {
+                continue;
+            }
+
+            DB
+                ::table('annotations')
+                ->where('id', $annotation->id)
+                ->update([
+                    'annotation_subtype' => null,
+                ])
+                ;
+        }
+    }
+}


### PR DESCRIPTION
This was an oversight in the original migration unifying all our comment
stuff.

@krues8dr @sethetter