### PR TITLE
Notify admins when user requests verification (#1043)

### DIFF
--- a/app/Http/Controllers/SponsorController.php
+++ b/app/Http/Controllers/SponsorController.php
@@ -8,6 +8,9 @@ use Response;
 use Validator;
 use Auth;
 use Input;
+use Mail;
+use App\Models\Role;
+use App\Models\User;
 
 
 class SponsorController extends Controller
@@ -64,6 +67,18 @@ class SponsorController extends Controller
             $request->meta_value = 0;
             $request->user_id = $user->id;
             $request->save();
+
+            // Send an email to all admins notifying of independent sponsor request
+            $admins = User::findByRoleName(Role::ROLE_ADMIN);
+
+            foreach($admins->all() as $admin) {
+                Mail::queue('email.notification.independent_sponsor_request', ['user' => $user], function ($message) use ($admin) {
+                    $message->subject('New Indpendent Sponsor Request');
+                    $message->from('sayhello@opengovfoundation.org', 'Madison');
+                    $message->to($admin->email);
+                });
+            }
+
         }
 
         return Response::json();

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -301,6 +301,18 @@ class UserController extends Controller
 
             Event::fire(MadisonEvent::VERIFY_REQUEST_USER, $user);
 
+            // Send an email to all admin users to notify of new user
+            // verification request.
+            $admins = User::findByRoleName(Role::ROLE_ADMIN);
+
+            foreach($admins->all() as $admin) {
+                Mail::queue('email.notification.verify_request_user', ['user' => $user, 'request' => $meta], function ($message) use ($admin) {
+                    $message->subject('New User Requesting Verification');
+                    $message->from('sayhello@opengovfoundation.org', 'Madison');
+                    $message->to($admin->email);
+                });
+            }
+
             return Response::json($this->growlMessage(['Your profile has been updated', 'Your verified status has been requested.'], 'success'));
         }
 

--- a/resources/views/email/notification/independent_sponsor_request.blade.php
+++ b/resources/views/email/notification/independent_sponsor_request.blade.php
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en-US">
+	<head>
+		<meta charset="utf-8" />
+	</head>
+	<body>
+
+		<p>A user - {{ $user['fname'] }} {{ $user['lname'] }} ({{ $user['email'] }}) has requested independent sponsor status.</p>
+
+        <p><a href="{{ URL::to('administrative-dashboard/verify-independent') }}">View Request</a></p>
+
+		<p>&ndash; The OpenGov Foundation Team</p>
+	</body>
+</html>

--- a/resources/views/email/notification/verify_request_group.blade.php
+++ b/resources/views/email/notification/verify_request_group.blade.php
@@ -16,7 +16,7 @@
     <p><strong>Postal Code:</strong> {{ $group['postal_code'] }}</p>
     <p><strong>Phone Number:</strong> {{ $group['phone_number'] }}</p>
 
-    <a href="{{ URL::to('dashboard/groupverifications') }}">View Request</a>
+    <a href="{{ URL::to('administrative-dashboard/verify-group') }}">View Request</a>
 
 	<p>&ndash; The OpenGov Foundation Team</p>
 	</body>


### PR DESCRIPTION
Note that this will be handled differently in dev where notifications are fixed
and working properly. In this case, there wasn't any sort of event handler for
the `VERIFY_REQUEST_USER` event that's fired here, so that will need to be added
in dev.

Issue #1043 

There will be a separate PR for doing this work in dev.

@krues8dr