### PR TITLE
Update the donate button to Mymadison paypal link instead of not working button. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ As of 4.0, Madison is a generally plain Laravel (PHP) application.
 
 ## User Guide
 
-Visit our [Engagement Guide](https://mymadison.io/sponsors/guide)
+Donate via [Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5XHFT7UGRZFH4)
 for information on using Madison to run engagement rounds.
 
 ## How to Help


### PR DESCRIPTION
The link on engagement does not work. So I added the PayPal link from MyMadison site.